### PR TITLE
Pack unit values as unit in tables and arrays

### DIFF
--- a/lib/Net/AMQP/Common.pm
+++ b/lib/Net/AMQP/Common.pm
@@ -227,10 +227,15 @@ sub pack_field_array {
 }
 
 sub _pack_field_value {
-    my ($value) = @_;
+    my ($value) = @_;    
     if (not ref $value) {
-        # FIXME - assuming that all values are string values
-        'S' . pack_long_string($value)
+        if ($value =~ /^\d+\z/) {
+            # Unsigned int
+            'I' . pack_long_integer($value)
+        } else {
+            # FIXME - assuming that all other values are string values
+            'S' . pack_long_string($value)
+        }
     }
     elsif (ref($value) eq 'HASH') {
         'F' . pack_field_table($value)


### PR DESCRIPTION
Hello,

Would you accept this patch to pack whole numbers as unit data type when encoding tables and arrays?

I'm not entirely happy with it, but I think without changing the API it'll always be a suboptimal solution given that the values come through without any type info. Regex seems the preferred way to determine the data type in this scenario( http://perldoc.perl.org/perlfaq4.html#How-do-I-determine-whether-a-scalar-is-a-number%2fwhole%2finteger%2ffloat%3f) but I wasn't sure what your intention for the FIXME was.

Thanks in advance for considering.

Dan
