### PR TITLE
fix tmp path building to avoid failures on cygwin

### DIFF
--- a/lib/Net/AMQP/Protocol.pm
+++ b/lib/Net/AMQP/Protocol.pm
@@ -264,7 +264,7 @@ sub full_docs_to_dir {
             }
 
             my ($volume, $directories, undef) = File::Spec->splitpath($filename);
-            my $base_path = File::Spec->catfile($volume, $directories);
+            my $base_path = File::Spec->catpath($volume, $directories);
             -d $base_path || mkpath($base_path) || die "Can't mkpath $base_path: $!";
 
             open my $podfn, '>', $filename or die "Can't open '$filename' for writing: $!";


### PR DESCRIPTION
catfile does not ignore a volume of "", and thus generates a path like "//tmp". this is a problem on cygwin as "//" is a meaningful path on windows (network groups).

catpath handles $volume correctly and generates "/tmp" if it's empty

@ewaters @chipdude if neither of you have the time to do a release of this with the fix, any chance of giving comaint to mithaldu on cpan so i can do it myself?